### PR TITLE
adding 2step list feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,14 @@ placeholder will be replaced with what has been entered.
 ## list files
 
 The second placeholder is the list placeholder. A list placeholder refers to
-a .list file.
+a .2step.list or a .list file.
 
 For example '<<list_docker_ps>>' is a list placeholder, because it matches the
 regex pattern '<<list_(.*)>>. The regex group match is the name of a list.
 In this example the name is docker_ps, which is a reference to a file named
 docker_ps.list under the macro directory.
 
+### .list files
 The .list files are scripts which should echo a list of options which will be
 supplied to another 'rofid -dmenu' call. The placeholder will be replaced with
 the selected option.
@@ -75,6 +76,19 @@ the selected option.
 Example macro with list placeholder is 'docker logs -f <<list_docker_ps>>'.
 So if the docker_ps.list script executes 'docker ps --format '{{ .Names }}''
 then the 'rofi -dmenu' call will show list of running container names.
+
+### .2step.list files
+
+A 2step list used in two steps to get a value to replace the list
+placeholder.
+
+In the first step it will be executed without parameters
+and it should return a list for selection. Items (lines) in this
+list could be a lot more descriptive, they could be rows from a table.
+
+In the second step the script will be executed with the selected by
+the user line. The script should parse this line and return a string
+which will replace the placeholder.
 
 ## modes
 

--- a/examples/docker.macro
+++ b/examples/docker.macro
@@ -1,0 +1,5 @@
+docker ps -a
+docker ps | awk '{print 1}'
+docker stop
+docker rm <<list_docker_ps_all>>
+docker logs -f --tail 100 <<list_docker_ps>>

--- a/examples/docker_ps.list
+++ b/examples/docker_ps.list
@@ -1,0 +1,1 @@
+docker ps --format '{{ .Names }}'

--- a/examples/docker_ps_all.2step.list
+++ b/examples/docker_ps_all.2step.list
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ "$*" = "" ]; then
+    docker ps -a
+else
+    echo "$*" | awk '{print $1}'
+fi

--- a/rofi-keyboard-macros
+++ b/rofi-keyboard-macros
@@ -92,10 +92,19 @@ function eval_macro_list() {
         local list_name=$(echo $list_place_holder | \
             sed -e 's/<<list_//g' -e 's/>>//g')
 
-        local list_script_name="${ROFI_KM_MACRO_DIR}/${list_name}.list"
+        # first check for 2step.list
+        local list_script_name="${ROFI_KM_MACRO_DIR}/${list_name}.2step.list"
+        local is_2step="yes"
+        if [ ! -f $list_script_name ]; then
+            list_script_name="${ROFI_KM_MACRO_DIR}/${list_name}.list"
+            is_2step="no"
+        fi
         local selected_list_item=$(echo "$(eval $list_script_name | $ROFI_KM_DMENU_CMD -p ${list_name})")
 
         if [ "$selected_list_item" != "" ]; then
+            if [ "$is_2step" = "yes" ]; then
+                selected_list_item=$($list_script_name "$selected_list_item")
+            fi
             macro="${macro/${list_place_holder}/${selected_list_item}}"
         else
             macro=""
@@ -188,5 +197,5 @@ function main() {
     fi
 }
 
-init "*@"
+init "$@"
 main


### PR DESCRIPTION
A list file could be named '.2step.list' or '.list'.
A 2step list used in two steps to get a value to replace the list
placeholder.

In the first step it will be executed without parameters
and it should return a list for selection. Items (lines) in this
list could be a lot more descriptive, they could be rows from a table.

In the second step the script will be executed with the selected by
the user line. The script should parse this line and return a string
which will replace the placeholder.